### PR TITLE
Update workflow and bump version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,4 +50,4 @@ jobs:
           tag_name: ${{ steps.get-version.outputs.version }}
           release_name: ${{ steps.get-version.outputs.version }}
           draft: true
-          files: ${{ steps.get-version.outputs.version }}.zip
+          files: extension.zip

--- a/package.json
+++ b/package.json
@@ -59,5 +59,5 @@
     "preview": "vite preview"
   },
   "type": "module",
-  "version": "0.0.1"
+  "version": "1.0.2"
 }


### PR DESCRIPTION
- Use `extension.zip` as name for packed extension release attachment
- Bum version